### PR TITLE
Use rimraf to clean-up temporary folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - Update Prettier rules (see #35).
 
+- Use `rimraf` instead of `rm -rf` (see #36).
+
 - Update dev dependencies to latest version.
 
 ### [v0.0.5](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/releases/tag/0.0.5) - 2017-09-26

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config .prettierrc --write {src,test}/**/*.ts",
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
-    "clean-up": "rm -rf .nyc_output && rm -rf coverage && rm -rf lib",
+    "clean-up": "rimraf .nyc_output && rimraf coverage && rimraf lib",
     "prepare": "npm run clean-up && tsc -d",
     "prepublishOnly": "publish-please guard",
     "publish-please": "npm run autoformat && npm run clean-up && npm run test && publish-please"


### PR DESCRIPTION
Use `rimraf` instead of `rm -rf` to clean-up temporary folders.